### PR TITLE
Panic when insert_raw is called with incorrect boxed type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.1 (2023-04-06)
+
+* Panic when `Resources::insert_raw` is called with mismatching `TypeId` and `Box<T>`. ([#11])
+
+[#11]: https://github.com/azriel91/resman/pull/11
+
 ## 0.16.0 (2022-12-26)
 
 * Add `Resources::insert_raw`. ([#9])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resman"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2021"
 description = "Runtime managed resource borrowing."

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Add the following to `Cargo.toml`
 resman = "0.16.0"
 
 # or
-resman = { version = "0.16.0", features = ["debug"] }
-resman = { version = "0.16.0", features = ["fn_res"] }
-resman = { version = "0.16.0", features = ["fn_res", "fn_res_mut"] }
-resman = { version = "0.16.0", features = ["fn_res", "fn_meta"] }
-resman = { version = "0.16.0", features = ["fn_res", "fn_res_mut", "fn_meta"] }
+resman = { version = "0.16.1", features = ["debug"] }
+resman = { version = "0.16.1", features = ["fn_res"] }
+resman = { version = "0.16.1", features = ["fn_res", "fn_res_mut"] }
+resman = { version = "0.16.1", features = ["fn_res", "fn_meta"] }
+resman = { version = "0.16.1", features = ["fn_res", "fn_res_mut", "fn_meta"] }
 
 # requires nightly
-resman = { version = "0.16.0", features = ["fn_res", "fn_res_mut", "fn_res_once"] }
+resman = { version = "0.16.1", features = ["fn_res", "fn_res_mut", "fn_res_once"] }
 ```
 
 In code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,14 @@
 //! resman = "0.16.0"
 //!
 //! # or
-//! resman = { version = "0.16.0", features = ["debug"] }
-//! resman = { version = "0.16.0", features = ["fn_res"] }
-//! resman = { version = "0.16.0", features = ["fn_res", "fn_res_mut"] }
-//! resman = { version = "0.16.0", features = ["fn_res", "fn_meta"] }
-//! resman = { version = "0.16.0", features = ["fn_res", "fn_res_mut", "fn_meta"] }
+//! resman = { version = "0.16.1", features = ["debug"] }
+//! resman = { version = "0.16.1", features = ["fn_res"] }
+//! resman = { version = "0.16.1", features = ["fn_res", "fn_res_mut"] }
+//! resman = { version = "0.16.1", features = ["fn_res", "fn_meta"] }
+//! resman = { version = "0.16.1", features = ["fn_res", "fn_res_mut", "fn_meta"] }
 //!
 //! # requires nightly
-//! resman = { version = "0.16.0", features = ["fn_res", "fn_res_mut", "fn_res_once"] }
+//! resman = { version = "0.16.1", features = ["fn_res", "fn_res_mut", "fn_res_once"] }
 //! ```
 //!
 //! In code:

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -110,6 +110,10 @@ impl Resources {
 
     /// Inserts an already boxed resource into the map.
     pub fn insert_raw(&mut self, type_id: TypeId, resource: Box<dyn Resource>) {
+        if type_id != Resource::type_id(&*resource) {
+            let type_name = Resource::type_name(&*resource);
+            panic!("`Resources::insert_raw` type_id does not match `{type_name:?}.type_id()`.");
+        }
         self.0.insert(type_id, resource);
     }
 
@@ -363,6 +367,20 @@ mod tests {
 
         assert!(resources.contains::<Res>());
         assert!(!resources.contains::<Foo>());
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "`Resources::insert_raw` type_id does not match `resman::resources::tests::Res.type_id()`."
+    )]
+    fn insert_raw_panics_when_boxed_resource_does_not_match_key() {
+        #[cfg_attr(feature = "debug", derive(Debug))]
+        struct Foo;
+
+        let mut resources = Resources::default();
+        resources.insert_raw(TypeId::of::<Foo>(), Box::new(Res));
+
+        assert!(resources.contains::<Res>());
     }
 
     #[test]


### PR DESCRIPTION
Gives developers better feedback when `insert_raw` is called incorrectly.